### PR TITLE
Fix crontab syntax for cron_file and a small typo

### DIFF
--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -112,7 +112,7 @@
     group: root
     mode: "0744"
 
-- name: Create initial certificate revocation list squence number
+- name: Create initial certificate revocation list sequence number
   ansible.builtin.shell: "echo 00 > crl_number"
   args:
     chdir: "{{ openvpn_key_dir }}"
@@ -179,6 +179,6 @@
     name: "check if CRL will expire soon"
     special_time: weekly
     job: "sh {{ openvpn_base_dir }}/crl-cron.sh"
-    cron_ansible.builtin.file: /etc/cron.d/openvpn-crl
+    cron_file: /etc/cron.d/openvpn-crl
     user: root
   when: not ci_build


### PR DESCRIPTION
- Fix a small typo on "sequence" word
- Fix cron_file on the CRL expiration crontab

CF: https://github.com/aovpn/ansible-role-openvpn/issues/5 