### PR TITLE
Add ansible-lint job to the pipeline

### DIFF
--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -9,7 +9,23 @@ on:
       - main
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+      - name: Run ansible lint
+        uses: ansible/ansible-lint-action@v6.17.0
+        with:
+          path: "."
+
+
   molecule:
+    needs:
+      - lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -81,7 +81,7 @@
     - openvpn_iptables_existing_save.rc == 0
   failed_when:
     - openvpn_iptables_existing_save.rc != 0
-  when: __iptables_installed.changed | bool
+  when: __iptables_installed.changed | bool # noqa no-handler
 
 - name: Enable iptables
   ansible.builtin.service:


### PR DESCRIPTION
Closes https://github.com/aovpn/ansible-role-openvpn/issues/29

Added `noqa no-handler` skip action to the `tasks/iptables.yml` as a workaround for now.