### PR TITLE
[#27] Remove support of the Fedora distribution

### DIFF
--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -1,3 +1,4 @@
+---
 name: Molecule Test
 
 on:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ OpenVPN
 =========
 This role installs OpenVPN from default repositories, configures it as a server, sets up networking and firewalls (primarily firewalld, ufw and iptables - best effort), and generates client configuration files. It also optionally supports LDAP authentication.
 
-Supported Operating Systems (CI Build):
-- Ubuntu 24.04
-- CentOS 8
+Supported Operating Systems:
+- Ubuntu 24.04 and higher
+- CentOS 9 and higher
+- Debian 11 and higher
 
 # Requirements
 OpenVPN must be available as a package in yum/dnf/apt! For CentOS users, this role will run `yum install epel-release` to ensure OpenVPN is available.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Change these options if you need to force a particular firewall or change how th
 | iptables_service                 | string  |                                | iptables | Override the iptables service name                                                                          |
 | manage_firewall_rules            | boolean | true, false                    | true     | Allow playbook to manage iptables                                                                           |
 | openvpn_firewall                 | string  | auto, firewalld, ufw, iptables | auto     | The firewall software to configure network rules. "auto" will attempt to detect it by inspecting the system |
-| openvpn_masquerade_not_snat      | boolean | true, false                    | false    | Set to true if you want to set up MASQUERADE instead of the default SNAT in iptables.                       |
 ## OpenVPN Config Options
 These options change how OpenVPN itself works.
 ### Networking

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,6 @@ firewalld_default_interface_zone: public
 iptables_service: iptables
 manage_firewall_rules: true
 openvpn_firewall: auto
-openvpn_masquerade_not_snat: false
 
 # Misc
 ci_build: false
@@ -45,7 +44,7 @@ openvpn_use_ldap: false
 ## Defaults for openvpn
 
 # Networking
-openvpn_client_register_dns: true
+openvpn_client_register_dns: false
 openvpn_client_to_client: false
 openvpn_custom_dns: []
 openvpn_dns_servers: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,10 +22,12 @@
     state: restarted
 
 - name: Enable iptables
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: "{{ iptables_service }}"
     state: started
     enabled: true
+  when:
+    - ansible_distribution != "Debian"
 
 - name: Save iptables rules (Debian/Ubuntu and CentOS/RHEL)
   ansible.builtin.shell:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
 
 - name: Restart iptables
   ansible.builtin.service:
-    name: iptables
+    name: "{{ iptables_service }}"
     state: restarted
 
 - name: Restart firewalld
@@ -21,7 +21,13 @@
     name: ufw
     state: restarted
 
-- name: Save iptables rules (Debian/Ubuntu and CentOS/RHEL/Fedora)
+- name: Enable iptables
+  ansible.builtin.systemd_service:
+    name: "{{ iptables_service }}"
+    state: started
+    enabled: true
+
+- name: Save iptables rules (Debian/Ubuntu and CentOS/RHEL)
   ansible.builtin.shell:
     cmd: "{{ iptables_save_command }}"  # noqa command-instead-of-shell
   register: openvpn_iptables_save

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,11 +13,6 @@ galaxy_info:
       versions:
         - "7"
         - "8"
-    - name: Fedora
-      versions:
-        - "32"
-        - "33"
-        - "34"
     - name: Ubuntu
       versions:
         - focal

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -22,7 +22,7 @@
 
 - name: Debug firewalls
   ansible.builtin.debug:
-    msg: "Firewalld: {{firewalld.rc}}, iptables: {{iptables.rc}}, ufw: {{ufw.rc}}"
+    msg: "Firewalld: {{ firewalld.rc }}, iptables: {{ iptables.rc }}, ufw: {{ ufw.rc }}"
   tags:
     - never
     - debug
@@ -42,7 +42,7 @@
 
 - name: Echo iptables_installed
   ansible.builtin.debug:
-    msg: "{{iptables_installed}}"
+    msg: "{{ iptables_installed }}"
   tags:
     - never
     - debug

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -20,6 +20,13 @@
   changed_when: false  # Never report as changed
   failed_when: false
 
+- name: Debug firewalls
+  ansible.builtin.debug:
+    msg: "Firewalld: {{firewalld.rc}}, iptables: {{iptables.rc}}, ufw: {{ufw.rc}}"
+  tags:
+    - never
+    - debug
+
 - name: Fail on both firewalld & ufw
   ansible.builtin.fail:
     msg: "Both FirewallD and UFW are detected, firewall situation is unknown"
@@ -33,6 +40,13 @@
   when: firewalld.rc != 0 and ufw.rc != 0 and iptables.rc != 0
   notify: "Enable iptables"
 
+- name: Echo iptables_installed
+  ansible.builtin.debug:
+    msg: "{{iptables_installed}}"
+  tags:
+    - never
+    - debug
+
 - name: Add port rules (iptables)
   ansible.builtin.include_tasks: iptables.yml
   when: >-
@@ -40,7 +54,7 @@
     or
     (openvpn_firewall == 'auto' and firewalld.rc != 0 and ufw.rc != 0 and iptables.rc == 0)
     or
-    (iptables_installed is defined)
+    (iptables_installed.stdout is defined)
 
 - name: Add port rules (firewalld)
   ansible.builtin.include_tasks: firewalld.yml

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -25,10 +25,13 @@
     msg: "Both FirewallD and UFW are detected, firewall situation is unknown"
   when: openvpn_firewall == 'auto' and firewalld.rc == 0 and ufw.rc == 0
 
-- name: Fail on no firewall detected
-  ansible.builtin.fail:
-    msg: "No firewall detected, install one before proceeding (firewalld||ufw||iptables)"
+- name: Installing iptables due to no firewall detected
+  ansible.builtin.package:
+    name: "{{ iptables_services_package_name }}"
+    state: present
+  register: iptables_installed
   when: firewalld.rc != 0 and ufw.rc != 0 and iptables.rc != 0
+  notify: "Enable iptables"
 
 - name: Add port rules (iptables)
   ansible.builtin.include_tasks: iptables.yml
@@ -36,6 +39,8 @@
     (openvpn_firewall == 'iptables')
     or
     (openvpn_firewall == 'auto' and firewalld.rc != 0 and ufw.rc != 0 and iptables.rc == 0)
+    or
+    (iptables_installed is defined)
 
 - name: Add port rules (firewalld)
   ansible.builtin.include_tasks: firewalld.yml

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -6,14 +6,6 @@
     masked: false
     state: started
 
-- name: Install python2-firewall (Fedora)
-  ansible.builtin.package:
-    name: "{{ python_firewall_package_name }}"
-    state: present
-  when:
-    - ansible_distribution == "Fedora"
-    - ansible_python.version.major == 2
-
 - name: Enable OpenVPN Port (firewalld)
   ansible.posix.firewalld:
     port: "{{ openvpn_port }}/{{ openvpn_proto }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,14 +28,6 @@
     - "rhel-ha-for-rhel-*-server-rpms"
   when: ansible_distribution=="RedHat" and ansible_distribution_major_version == "7"
 
-- name: Install python2-dnf for Fedora dnf support
-  ansible.builtin.raw: dnf install -y python2-dnf
-  when:
-    - ansible_distribution == "Fedora"
-    - ansible_python.version.major == 2
-  register: fedora_dnf
-  changed_when: '"Nothing to do." not in fedora_dnf.stdout'
-
 - name: Update repositories for Debian/Ubuntu
   ansible.builtin.apt:
     update_cache: true

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -5,29 +5,22 @@
     state: present
   when: ansible_os_family == "Debian"
 
-- name: Install iptables-services (RedHat/CentOS)
-  ansible.builtin.package:
-    name: "{{ iptables_services_package_name }}"
-    state: present
-  when: ansible_os_family == "RedHat"
-
-- name: Allow VPN forwarding - iptables
+- name: Allow VPN forwarding - input - iptables
   ansible.builtin.iptables:
     chain: FORWARD
     source: "{{ openvpn_server_network }}/24"
     jump: ACCEPT
     action: insert
-    comment: "Allow VPN forwarding"
+    comment: "Allow VPN forwarding for inbound traffic"
   notify: "save iptables"
 
-- name: Allow incoming SSH connections - iptables
+- name: Allow VPN forwarding - output - iptables
   ansible.builtin.iptables:
-    chain: INPUT
-    protocol: tcp
-    destination_port: "{{ ansible_port | default(22) }}"
+    chain: FORWARD
+    destination: "{{ openvpn_server_network }}/24"
     jump: ACCEPT
     action: insert
-    comment: "Allow incoming SSH connection"
+    comment: "Allow VPN forwarding for outbound traffic"
   notify: "save iptables"
 
 - name: Allow incoming VPN connections - iptables
@@ -49,18 +42,6 @@
     comment: "Accept packets from VPN tunnel adaptor"
   notify: "save iptables"
 
-- name: Perform NAT readdressing - iptables
-  ansible.builtin.iptables:
-    table: nat
-    chain: POSTROUTING
-    source: "{{ openvpn_server_network }}/24"
-    to_source: "{{ ansible_default_ipv4.address }}"
-    jump: SNAT
-    action: insert
-    comment: "Perform NAT readdressing"
-  when: not openvpn_masquerade_not_snat
-  notify: "save iptables"
-
 - name: Perform NAT readdressing with MASQUERADE - iptables
   ansible.builtin.iptables:
     table: nat
@@ -69,11 +50,4 @@
     jump: MASQUERADE
     action: insert
     comment: "Perform NAT readdressing"
-  when: openvpn_masquerade_not_snat
   notify: "save iptables"
-
-- name: Enable iptables
-  ansible.builtin.service:
-    name: "{{ iptables_service }}"
-    enabled: true
-    state: started

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -4,7 +4,7 @@
   register: semodule_loaded
   changed_when: 'openvpn_selinux_module not in semodule_loaded.stdout'
   notify:
-    - build and install policy
+    - Build and install policy
 
 - name: SELinux - copy type enforcement file
   ansible.builtin.template:
@@ -12,4 +12,4 @@
     dest: /var/lib/selinux/{{ openvpn_selinux_module }}.te
     mode: "0644"
   notify:
-    - build and install policy
+    - Build and install policy

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -10,27 +10,17 @@
     openvpn_service_name: "openvpn@{{ openvpn_config_file }}.service"
   when: ansible_service_mgr == "systemd" or (docker_stat_result.stat is defined and docker_stat_result.stat.exists)
 
-# Fedora and CentOS 8 separate OpenVPN into client and server
-- name: Set Fedora 27+ and CentOS 8 service name
+# Separate OpenVPN into client and server for CentOS/Rocky/RHEL
+- name: Set service name for CentOS/Rocky/RHEL
   ansible.builtin.set_fact:
     openvpn_service_name: "openvpn-server@{{ openvpn_config_file }}.service"
-  when: >-
-    (ansible_distribution == "Fedora" and ansible_distribution_version|int >= 27)
-    or
-    (
-      ( (ansible_distribution == "CentOS") or (ansible_distribution == "Rocky") or (ansible_distribution == "RedHat") )
-      and
-      (ansible_distribution_version | int) >= 8
-    )
+  when:
+    - ansible_distribution == "CentOS" or ansible_distribution == "Rocky" or ansible_distribution == "RedHat"
+    - (ansible_distribution_version | int) >= 8
 
-- name: Set Fedora 27+ and CentOS 8 OpenVPN base path
+- name: Set OpenVPN base path for CentOS/Rocky/RHEL
   ansible.builtin.set_fact:
     openvpn_base_dir: "/etc/openvpn/server"
-  when: >-
-    (ansible_distribution == "Fedora" and ansible_distribution_version|int >= 27)
-    or
-    (
-      (ansible_distribution == "CentOS" or ansible_distribution == "Rocky" or ansible_distribution == "RedHat" )
-      and
-      (ansible_distribution_version | int) >= 8
-    )
+  when:
+    - ansible_distribution == "CentOS" or ansible_distribution == "Rocky" or ansible_distribution == "RedHat"
+    - (ansible_distribution_version | int) >= 8

--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -30,21 +30,6 @@
     interface: tun0
     rule: allow
 
-- name: Setup nat table rules - ufw
-  ansible.builtin.blockinfile:
-    dest: /etc/ufw/before.rules
-    state: present
-    insertbefore: \*filter
-    block: |
-      # OpenVPN config
-      *nat
-      :POSTROUTING ACCEPT [0:0]
-      -A POSTROUTING -s {{ openvpn_server_network }}/24 -j SNAT --to-source {{ ansible_default_ipv4.address }}
-      COMMIT
-  when: not openvpn_masquerade_not_snat
-  notify:
-    - Restart ufw
-
 - name: Setup nat table rules with MASQUERADE - ufw
   ansible.builtin.blockinfile:
     dest: /etc/ufw/before.rules
@@ -56,6 +41,5 @@
       :POSTROUTING ACCEPT [0:0]
       -A POSTROUTING -s {{ openvpn_server_network }}/24 -j MASQUERADE
       COMMIT
-  when: openvpn_masquerade_not_snat
   notify:
     - Restart ufw

--- a/tests/fedora-latest.dockerfile
+++ b/tests/fedora-latest.dockerfile
@@ -1,2 +1,0 @@
-FROM fedora:latest
-RUN dnf install -y systemd && dnf clean all

--- a/tests/install-fedora-latest
+++ b/tests/install-fedora-latest
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -ev
-sudo docker build -f tests/${INSTALL}.dockerfile -t ${DOCKER_TAG} .

--- a/tests/setup-fedora
+++ b/tests/setup-fedora
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ev
-sudo docker exec ${OS} dnf clean all
-sudo docker exec ${OS} dnf -y install ansible python3-pyyaml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: 127.0.0.1
+- name: Test
+  hosts: 127.0.0.1
   connection: local
   vars:
     ci_build: true

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,3 @@
 ---
 iptables_save_command: /usr/sbin/netfilter-persistent save
+iptables_services_package_name: iptables


### PR DESCRIPTION
Also install iptables by default if there is no installed firewall.
Add rule for iptables to enable outbound traffic forwarding for openvpn.
And a few other fixes.

Closes #27