### PR TITLE
Add removing of revoked client cert

### DIFF
--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -10,8 +10,8 @@ driver:
 lint: |
   ansible-lint
 platforms:
-  - name: centos8
-    image: geerlingguy/docker-centos8-ansible
+  - name: Rockylinux9
+    image: geerlingguy/docker-rockylinux9-ansible:latest
     privileged: true
     pre_build_image: true
     cgroupns_mode: host

--- a/tasks/revocation.yml
+++ b/tasks/revocation.yml
@@ -34,3 +34,12 @@
   with_items:
     - '{{ openvpn_revoke_these_certs }}'
     - '{{ openvpn_cert_sync_revoke | default([]) }}'
+
+- name: Remove client cert
+  ansible.builtin.file:
+    path: "{{ openvpn_key_dir }}/{{ item }}.crt"
+    state: absent
+    force: true
+  with_items:
+    - '{{ openvpn_revoke_these_certs }}'
+    - '{{ openvpn_cert_sync_revoke | default([]) }}'


### PR DESCRIPTION
Fix for https://github.com/aovpn/ansible-role-openvpn/issues/36

Molecule test for rhel based distros was updated, because Centos 8 and Rocky Linux 8 contains the old version of python - incompatible with the new version of ansible.